### PR TITLE
🔧 Fix Immutable token symbol from DARA to IMX

### DIFF
--- a/src/config/watchlist.ts
+++ b/src/config/watchlist.ts
@@ -6,7 +6,7 @@ export const watchlistConfig: WatchlistConfig = {
     'hyperliquid', 'render-token', 'sui', 'penguin-karts', 'rekt', 'ena', 
     'pepe', 'shiba-inu', 'dogecoin', 'cardano', 'polkadot', 'chainlink', 
     'avalanche-2', 'polygon', 'cosmos', 'uniswap', 'aptos', 'optimism', 
-    'arbitrum', 'stacks', 'ordi', 'sei-network', 'celestia', 'immutable'
+    'arbitrum', 'stacks', 'ordi', 'sei-network', 'celestia', 'immutable-x'
   ],
   stockSymbols: [
     'MSTR', 'COIN', 'HOOD', 'CRCL', 'IREN', 'CORZ', 'CIFR', 'RIOT', 


### PR DESCRIPTION
- Change CoinGecko ID from 'immutable' to 'immutable-x'
- Fix incorrect symbol 'dara' to correct symbol 'imx'
- Use proper Immutable (IMX) token instead of Immutable (DARA)
- Ensure predictions show correct cryptocurrency symbols
- Maintain data integrity and prevent confusion from wrong symbols