### PR TITLE
Fix VoiceProvider context error

### DIFF
--- a/src/app/voice/page.tsx
+++ b/src/app/voice/page.tsx
@@ -177,15 +177,14 @@ function VoiceExperience() {
           >
             <StartCall />
           </motion.div>
-          
-          <div className="mt-8">
-            <Controls />
-          </div>
         </div>
 
         {/* Bottom Gradient */}
         <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-black to-transparent" />
       </div>
+
+      {/* Controls - only rendered when connected */}
+      <Controls />
     </VoiceProvider>
   );
 }


### PR DESCRIPTION
- Move Controls component inside VoiceProvider to fix 'useVoice must be used within VoiceProvider' error
- Controls now properly renders within the voice context when connected
- Resolves context hook error that was preventing voice interface from working